### PR TITLE
highlight editor when regex is invalid

### DIFF
--- a/lib/tab-pair-header-source.js
+++ b/lib/tab-pair-header-source.js
@@ -86,9 +86,36 @@ export default {
     this.pairRegExp = []
     var useAdvancedMatch = atom.config.get('tab-pair-header-source.advancedMode.enable');
     if (useAdvancedMatch) {
+      // get editor element so we can mark it in error
+      var invalid_regexp = false;
+      var editor = null;
+      var n = document.evaluate('//*[text()="' + "Advanced Mode Match Reg Exp" + '"]', document, null, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE).snapshotItem(0);
+      if (n !== null) {
+        var editors = n.parentElement.parentElement.getElementsByClassName('editor-container');
+        if (editors.length > 0) {
+          editor = editors[0];
+        }
+      }
+      
       var pairPatterns = atom.config.get('tab-pair-header-source.advancedMode.matchRegExp');
       for(let index=0; index < pairPatterns.length; index++) {
-        this.pairRegExp.push( RegExp(pairPatterns[index]) );
+        try {
+          let regex = RegExp(pairPatterns[index]);
+          this.pairRegExp.push( regex );
+        }
+        catch(err) {
+          if (atom.inDevMode()) {
+            console.log("invalid regexp")
+          }
+          // get advanced config settings line, add class highlight-error
+          invalid_regexp = true;
+          if (editor !== null) {
+            editor.classList.add('highlight-error'); 
+          }
+        }
+      }
+      if (editor !== null && !invalid_regexp) {
+        editor.classList.remove('highlight-error'); 
       }
     }
     else { //basic mode, automatically construct regex


### PR DESCRIPTION
fix for bug #3 
highlights settings line if advanced mode regex is improper
